### PR TITLE
Fix broken config screen.

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -11,17 +11,17 @@
             {
                 "file": "images/menu_icon.png",
                 "name": "IMAGE_MENU_ICON",
-                "type": "png"
+                "type": "bitmap"
             },
             {
                 "file": "images/logo_splash.png",
                 "name": "IMAGE_LOGO_SPLASH",
-                "type": "png"
+                "type": "bitmap"
             },
             {
                 "file": "images/tile_splash.png",
                 "name": "IMAGE_TILE_SPLASH",
-                "type": "png"
+                "type": "bitmap"
             },
             {
                 "file": "fonts/UbuntuMono-Regular.ttf",
@@ -34,8 +34,9 @@
                 "type": "png"
             },
             {
-                "file": "images/cog_12.png",
-                "name": "IMAGES_COG_12_PNG",
+                "file": "images/trello-logo_28.png",
+                "menuIcon": true,
+                "name": "IMAGES_TRELLO_LOGO_28_PNG",
                 "type": "png"
             },
             {
@@ -44,15 +45,18 @@
                 "type": "png"
             },
             {
-                "file": "images/trello-logo_28.png",
-                "menuIcon": true,
-                "name": "IMAGES_TRELLO_LOGO_28_PNG",
+                "file": "images/cog_12.png",
+                "name": "IMAGES_COG_12_PNG",
                 "type": "png"
             }
         ]
     },
     "sdkVersion": "3",
     "shortName": "Unofficial Support for Trello",
+    "targetPlatforms": [
+        "aplite",
+        "basalt"
+    ],
     "uuid": "1f4e3b2f-36fa-4f6e-a5ca-a98204dd4b94",
     "versionCode": 1,
     "versionLabel": "1.3",

--- a/src/Trello.js
+++ b/src/Trello.js
@@ -325,7 +325,7 @@ var Trello = {
      * @returns {String}
      */
     getAuthorizationURL: function () {
-        return config.API_URL + '/authorize?callback_method=fragment&scope=read,write&expiration=never&name=' + config.name + '&key=' + config.API_KEY + '&return_url=' + config.API_RETURN_URL;
+        return config.API_URL + '/authorize?callback_method=fragment&scope=read,write&expiration=never&name=' + encodeURIComponent(config.name) + '&key=' + config.API_KEY + '&return_url=' + config.API_RETURN_URL;
     },
     
     

--- a/src/app.js
+++ b/src/app.js
@@ -29,8 +29,8 @@ Pebble.addEventListener("webviewclosed", function (e) {
     var token = false;
     if (e && e.response) {
         try {
-            e.response = JSON.parse(e.response);
-            token = e.response.token;
+            resp = JSON.parse(e.response);
+            token = resp.token;
         }
         catch (error) {
             console.log("[CONFIG]: Failed to parse:" + error);

--- a/src/config.js
+++ b/src/config.js
@@ -1,11 +1,11 @@
 var config = {
     name: 'Unofficial Support for Trello',
-    version: '1.3',
+    version: '1.4',
     cache: false,
     
     //API SETTINGS;
     API_URL:    'https://trello.com/1',                    //Trello API URL (moving here from Trello class);
-    API_KEY:    '',        //Trello API Key;
+    API_KEY:    '259487aa69671ac9aafc5f8672ffe0f7',        //Trello API Key;
     API_SECRET:  '', //Trello API Secret (though not actually needed for this);
     API_RETURN_URL:  'http://clintoncrick.com/prello/',    //URL to any page which can take hash value and direct to this app;
 };


### PR DESCRIPTION
At least on iOS, config screen doesn't load anymore. I had to:
- encodeURI the app name to remove spaces (otherwise the Trello authorization URL was invalid)
- change the way the token parsing is done, previous way resulted in "undefined"
- put back the trello API_KEY (not sure how it could work without it before?)

Changes to appinfo.json seemed to have been automatically done by  cloudpebble...

PS: This is my _first ever_ pull request on github, so let me know if I did something wrong!
